### PR TITLE
Define sles images in exernal task yamls

### DIFF
--- a/concourse/pipeline/pipeline-gpdb4.yml
+++ b/concourse/pipeline/pipeline-gpdb4.yml
@@ -27,12 +27,6 @@ resources:
     tag: '6-gcc6.2-llvm3.7'
 
 
-- name: sles-gpdb-dev-11-beta
-  type: docker-image
-  source:
-    repository: pivotaldata/sles-gpdb-dev
-    tag: '11-beta'
-
 - name: centos-gpdb-dev-5
   type: docker-image
   source:
@@ -51,7 +45,7 @@ resources:
 - name: plr_src
   type: git
   source:
-    branch: master 
+    branch: master
     uri: https://github.com/greenplum-db/plr.git
 
 # centos 7
@@ -195,10 +189,8 @@ jobs:
       trigger: true
     - get: bin_gpdb4_suse11
       trigger: true
-    - get: sles-gpdb-dev-11-beta
   - task: r_suse11_build
-    file: plr_src/concourse/tasks/build_r.yml
-    image: sles-gpdb-dev-11-beta
+    file: plr_src/concourse/tasks/build_r_sles.yml
     output_mapping:
       bin_r: gpdb4_bin_r_suse11
     params:
@@ -271,7 +263,6 @@ jobs:
   plan:
   - aggregate:
     - get: plr_src
-    - get: sles-gpdb-dev-11-beta
     - get: bin_gpdb4_suse11
     - get: gpdb4_bin_r_suse11
       passed: [GPDB4_Build_R_SUSE11]
@@ -279,8 +270,7 @@ jobs:
     - get: gpdb_src
   - aggregate:
     - task: Build_PLR
-      file: plr_src/concourse/tasks/build_plr.yml
-      image: sles-gpdb-dev-11-beta
+      file: plr_src/concourse/tasks/build_plr_sles11.yml
       input_mapping:
         bin_gpdb: bin_gpdb4_suse11
         bin_r: gpdb4_bin_r_suse11

--- a/concourse/pipeline/pipeline-gpdb5.yml
+++ b/concourse/pipeline/pipeline-gpdb5.yml
@@ -31,12 +31,6 @@ resources:
     repository: pivotaldata/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
 
-- name: sles-gpdb-dev-11-beta
-  type: docker-image
-  source:
-    repository: pivotaldata/sles-gpdb-dev
-    tag: '11-beta'
-
 # Github Source Codes
 
 - name: gpdb_src
@@ -48,7 +42,7 @@ resources:
 - name: plr_src
   type: git
   source:
-    branch: master 
+    branch: master
     uri: https://github.com/greenplum-db/plr.git
 
 # centos 7
@@ -192,10 +186,8 @@ jobs:
       trigger: true
     - get: bin_gpdb_suse11
       trigger: true
-    - get: sles-gpdb-dev-11-beta
   - task: r_suse11_build
-    file: plr_src/concourse/tasks/build_r.yml
-    image: sles-gpdb-dev-11-beta
+    file: plr_src/concourse/tasks/build_r_sles.yml
     output_mapping:
       bin_r: bin_r_suse11
     params:
@@ -268,7 +260,6 @@ jobs:
   plan:
   - aggregate:
     - get: plr_src
-    - get: sles-gpdb-dev-11-beta
     - get: bin_gpdb_suse11
     - get: bin_r_suse11
       passed: [Build_R_SUSE11]
@@ -276,8 +267,7 @@ jobs:
     - get: gpdb_src
   - aggregate:
     - task: Build_PLR
-      file: plr_src/concourse/tasks/build_plr.yml
-      image: sles-gpdb-dev-11-beta
+      file: plr_src/concourse/tasks/build_plr_sles.yml
       input_mapping:
         bin_gpdb: bin_gpdb_suse11
         bin_r: bin_r_suse11
@@ -336,7 +326,6 @@ jobs:
 - name: plr_suse11_test
   plan:
   - aggregate:
-    - get: sles-gpdb-dev-11-beta
     - get: plr_src
     - get: plr_gpdb_suse11_build
       passed: [plr_suse11_build]
@@ -344,8 +333,7 @@ jobs:
     - get: bin_gpdb_suse11
     - get: gpdb_src
   - task: Test_PLR
-    file: plr_src/concourse/tasks/test_plr.yml
-    image: sles-gpdb-dev-11-beta
+    file: plr_src/concourse/tasks/test_plr_sles.yml
     input_mapping:
       bin_gpdb: bin_gpdb_suse11
       bin_plr: plr_gpdb_suse11_build

--- a/concourse/pipeline/pipeline-release-gpdb4.yml
+++ b/concourse/pipeline/pipeline-release-gpdb4.yml
@@ -19,12 +19,6 @@ resources:
     repository: pivotaldata/centos-gpdb-dev
     tag: '6-gcc6.2-llvm3.7'
 
-- name: sles-gpdb-dev-11-beta
-  type: docker-image
-  source:
-    repository: pivotaldata/sles-gpdb-dev
-    tag: '11-beta'
-
 - name: centos-gpdb-dev-5
   type: docker-image
   source:
@@ -36,7 +30,7 @@ resources:
 - name: plr_src
   type: git
   source:
-    branch: master 
+    branch: master
     uri: https://github.com/greenplum-db/plr.git
     tag_filter: 2.*
 
@@ -153,13 +147,11 @@ jobs:
 - name: gpdb4_plr_suse11_release
   plan:
   - aggregate:
-    - get: sles-gpdb-dev-11-beta
     - get: plr_gpdb4_suse11_build
     - get: plr_src
       trigger: true
   - task: Test_PLR
-    file: plr_src/concourse/tasks/release_plr.yml
-    image: sles-gpdb-dev-11-beta
+    file: plr_src/concourse/tasks/release_plr_sles.yml
     input_mapping:
       bin_plr: plr_gpdb4_suse11_build
     output_mapping:

--- a/concourse/pipeline/pipeline-release-gpdb5.yml
+++ b/concourse/pipeline/pipeline-release-gpdb5.yml
@@ -25,24 +25,18 @@ resources:
     repository: pivotaldata/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
 
-- name: sles-gpdb-dev-11-beta
-  type: docker-image
-  source:
-    repository: pivotaldata/sles-gpdb-dev
-    tag: '11-beta'
-
 # Github Source Codes
 
 - name: plr_src
   type: git
   source:
-    branch: master 
+    branch: master
     uri: https://github.com/greenplum-db/plr.git
 
 - name: release_src
   type: git
   source:
-    branch: master 
+    branch: master
     uri: https://github.com/greenplum-db/plr.git
     tag_filter: 2.*
 
@@ -157,14 +151,12 @@ jobs:
 - name: plr_suse11_release
   plan:
   - aggregate:
-    - get: sles-gpdb-dev-11-beta
     - get: plr_src
     - get: plr_gpdb_suse11_build
     - get: release_src
       trigger: true
   - task: release_PLR
-    file: plr_src/concourse/tasks/release_plr.yml
-    image: sles-gpdb-dev-11-beta
+    file: plr_src/concourse/tasks/release_plr_sles.yml
     input_mapping:
       bin_plr: plr_gpdb_suse11_build
     output_mapping:

--- a/concourse/tasks/build_plr_sles.yml
+++ b/concourse/tasks/build_plr_sles.yml
@@ -1,0 +1,25 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/sles-gpdb-dev
+    tag: '11-beta'
+
+inputs:
+- name: bin_gpdb
+- name: plr_src
+- name: bin_r
+- name: gpdb_src
+
+outputs:
+- name: bin_plr
+
+run:
+  path: plr_src/concourse/scripts/build_plr.sh
+
+params:
+  OSVER:
+  GPDBVER:

--- a/concourse/tasks/build_r_sles.yml
+++ b/concourse/tasks/build_r_sles.yml
@@ -1,0 +1,21 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/sles-gpdb-dev
+    tag: '11-beta'
+
+inputs:
+- name: plr_src
+
+outputs:
+- name: bin_r
+
+run:
+  path: plr_src/concourse/scripts/build_r.sh
+
+params:
+  OSVER:

--- a/concourse/tasks/release_plr_sles.yml
+++ b/concourse/tasks/release_plr_sles.yml
@@ -1,0 +1,23 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/sles-gpdb-dev
+    tag: '11-beta'
+
+inputs:
+- name: plr_src
+- name: bin_plr
+
+outputs:
+  - name: plr_gppkg
+
+run:
+  path: plr_src/concourse/scripts/release_plr.sh
+
+params:
+  OSVER:
+  GPDBVER:


### PR DESCRIPTION
I see a few builds using sles images on the CI pipelines for plr failing with:
```
runc create: exit status 1: container_linux.go:264: starting container process caused "process_linux.go:339: container init caused \"rootfs_linux.go:57: mounting \\\"/var/vcap/data/baggageclaim/volumes/live/cfe10152-1f6e-40a3-66d0-e6f0763b16a1/volume\\\" to rootfs \\\"/var/vcap/data/garden/graph/aufs/mnt/2b2d9d6af0b3e7ef7e94e360017784ed21d87b7430a2bd587d6490c7f0fd881c\\\" at \\\"/var/vcap/data/garden/graph/aufs/mnt/2b2d9d6af0b3e7ef7e94e360017784ed21d87b7430a2bd587d6490c7f0fd881c/scratch\\\" caused \\\"mkdir /var/vcap/data/garden/graph/aufs/mnt/2b2d9d6af0b3e7ef7e94e360017784ed21d87b7430a2bd587d6490c7f0fd881c/scratch: permission denied\\\"\""
```

The CI pipelines don't trigger often so it has not happened many times, but this is a known issue that we have a fix for. We don't generally like the pattern of having task yaml that is defined for specific platforms, but in this case it's the best way to craft the pipeline to handle this one edge case for sles images. 