### PR TITLE
Ignore detailed information of drop statement.

### DIFF
--- a/regress/expected/plr.out
+++ b/regress/expected/plr.out
@@ -905,5 +905,3 @@ DROP TYPE IF EXISTS vtup CASCADE;
 drop table if exists foo cascade; 
 NOTICE:  drop cascades to function get_foo(integer)
 -- end_ignore
-\!echo $?
-0

--- a/regress/expected/plr.out
+++ b/regress/expected/plr.out
@@ -823,6 +823,7 @@ select * from restore_df((select test_serialize('select oid, typname from pg_typ
 (3 rows)
 
 --now cleaning 
+-- start_ignore
 DROP FUNCTION plr_call_handler() cascade; 
 NOTICE:  drop cascades to language plr
 NOTICE:  drop cascades to function restore_df(bytea)
@@ -903,3 +904,6 @@ DROP TYPE IF EXISTS mtup CASCADE;
 DROP TYPE IF EXISTS vtup CASCADE; 
 drop table if exists foo cascade; 
 NOTICE:  drop cascades to function get_foo(integer)
+-- end_ignore
+\!echo $?
+0

--- a/regress/sql/plr.sql
+++ b/regress/sql/plr.sql
@@ -330,4 +330,3 @@ DROP TYPE IF EXISTS mtup CASCADE;
 DROP TYPE IF EXISTS vtup CASCADE; 
 drop table if exists foo cascade; 
 -- end_ignore
-\!echo $?

--- a/regress/sql/plr.sql
+++ b/regress/sql/plr.sql
@@ -319,6 +319,7 @@ returns setof record as '
 select * from restore_df((select test_serialize('select oid, typname from pg_type where typname in (''oid'',''name'',''int4'')'))) as t(oid oid, typname name);
 
 --now cleaning 
+-- start_ignore
 DROP FUNCTION plr_call_handler() cascade; 
 DROP TYPE IF EXISTS plr_environ_type cascade; 
 DROP TYPE IF EXISTS r_typename cascade; 
@@ -328,3 +329,5 @@ DROP TYPE IF EXISTS dtup CASCADE;
 DROP TYPE IF EXISTS mtup CASCADE; 
 DROP TYPE IF EXISTS vtup CASCADE; 
 drop table if exists foo cascade; 
+-- end_ignore
+\!echo $?


### PR DESCRIPTION
gpdb_master code change the order or drop result in drop table statement.
To support both gpdb_mster and 5X_stable, we ignore the detailed informatin of drop statement