### PR TITLE
Add type conversion functions of PL\R

### DIFF
--- a/regress/expected/plr.out
+++ b/regress/expected/plr.out
@@ -822,6 +822,36 @@ select * from restore_df((select test_serialize('select oid, typname from pg_typ
   26 | oid
 (3 rows)
 
+CREATE OR REPLACE FUNCTION rlargeint8out(n int) RETURNS int8[] AS $$
+matrix(2, 1, n)
+$$ LANGUAGE plr;
+CREATE OR REPLACE FUNCTION routfloat4(n int) RETURNS float4[] AS $$
+vector(mode = "numeric", length = n)
+$$ LANGUAGE plr;
+SELECT rlargeint8out(10);
+      rlargeint8out      
+-------------------------
+ {{2,2,2,2,2,2,2,2,2,2}}
+(1 row)
+
+SELECT routfloat4(10);
+      routfloat4       
+-----------------------
+ {0,0,0,0,0,0,0,0,0,0}
+(1 row)
+
+SELECT count(rlargeint8out(15000));
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(routfloat4(15000));
+ count 
+-------
+     1
+(1 row)
+
 --now cleaning 
 -- start_ignore
 DROP FUNCTION plr_call_handler() cascade; 

--- a/regress/sql/plr.sql
+++ b/regress/sql/plr.sql
@@ -318,6 +318,20 @@ returns setof record as '
 
 select * from restore_df((select test_serialize('select oid, typname from pg_type where typname in (''oid'',''name'',''int4'')'))) as t(oid oid, typname name);
 
+CREATE OR REPLACE FUNCTION rlargeint8out(n int) RETURNS int8[] AS $$
+matrix(2, 1, n)
+$$ LANGUAGE plr;
+
+CREATE OR REPLACE FUNCTION routfloat4(n int) RETURNS float4[] AS $$
+vector(mode = "numeric", length = n)
+$$ LANGUAGE plr;
+
+SELECT rlargeint8out(10);
+SELECT routfloat4(10);
+
+SELECT count(rlargeint8out(15000));
+SELECT count(routfloat4(15000));
+
 --now cleaning 
 -- start_ignore
 DROP FUNCTION plr_call_handler() cascade; 


### PR DESCRIPTION
PL\R already has a few of type conversion functions to
convert R SEXP object to GPDB Datum. However, the conversion
functions from R SEXP to GPDB datum only has INT4, FLOAT8,
Bytea and String functions. This commit added other missing
Integer and Float datatype conversion functions, which can increase
the performance of data conversion a lot.