### PR TITLE
Backport PLR commit about failing function body parsing

### DIFF
--- a/regress/expected/bad_fun.out
+++ b/regress/expected/bad_fun.out
@@ -1,0 +1,13 @@
+-- should error out but should not crash PG
+CREATE OR REPLACE
+FUNCTION r_bad_fun()
+RETURNS int4 AS
+$BODY$
+  deadbeef <- function(,bad) {}
+  42
+$BODY$
+LANGUAGE plr;
+SELECT r_bad_fun();
+ERROR:  R interpreter parse error
+DETAIL:  Error: bad value
+CONTEXT:  In PL/R function r_bad_fun

--- a/regress/sql/bad_fun.sql
+++ b/regress/sql/bad_fun.sql
@@ -1,0 +1,11 @@
+-- should error out but should not crash PG
+CREATE OR REPLACE
+FUNCTION r_bad_fun()
+RETURNS int4 AS
+$BODY$
+  deadbeef <- function(,bad) {}
+  42
+$BODY$
+LANGUAGE plr;
+
+SELECT r_bad_fun();

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ SHLIB_LINK	+= -L$(r_libdir1x) -L$(r_libdir2x) -lR
 DATA_built	= plr.sql
 DATA		= plr--8.3.0.16.sql plr--unpackaged--8.3.0.16.sql
 DOCS		= README.plr
-REGRESS		= plr
+REGRESS		= plr bad_fun
 EXTRA_CLEAN	= doc/html/* doc/plr-US.aux doc/plr-*.log doc/plr-*.out doc/plr-*.pdf doc/plr-*.tex-pdf
 
 ifdef USE_PGXS
@@ -74,7 +74,6 @@ override CPPFLAGS += -DPKGLIBDIR=\"$(pkglibdir)\" -DDLSUFFIX=\"$(DLSUFFIX)\"
 override CPPFLAGS += -DR_HOME_DEFAULT=\"$(rhomedef)\"
 
 REGRESS_OPTS = --dbname=$(PL_TESTDB)
-REGRESS = plr
 
 .PHONY: release
 release:


### PR DESCRIPTION
This is a backport patch from
https://github.com/postgres-plr/plr/commit/c42eb9ce0b52a92a1d075e927db26a914100a860
to fix GPDB crash, when the R function is not correct in UDF