### PR TITLE
Update concourse pipeline to move to GCP/GCS

### DIFF
--- a/concourse/pipeline/pipeline-release.yml
+++ b/concourse/pipeline/pipeline-release.yml
@@ -10,6 +10,12 @@ groups:
     - plr_centos6_test
     - plr_centos7_test
 
+resource_types:
+- name: gcs
+  type: docker-image
+  source:
+    repository: frodenas/gcs-resource
+
 resources:
 
 # Image Resources
@@ -44,30 +50,27 @@ resources:
 # centos 7
 
 - name: plr_gpdb_centos7_build
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
+    region_name: us-west-1
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
     versioned_file: build/gpdb6/plr/centos7/plr-devel.gppkg
 
 - name: plr_gpdb_centos7_release
-  type: s3
+  type: gcs
   source:
-    bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
+    json_key: {{gcs-read-write-service-account-key}}
+    region_name: us-west-1
     secret_access_key: {{bucket-secret-access-key}}
     regexp: release/gpdb6/plr/plr-(.*)-rhel7-x86_64.gppkg
 
 - name: plr_gpdb_centos7_release_candidate
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
+    region_name: us-west-1
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
     regexp: release_candidate/gpdb6/plr/plr-(.*)-rhel7-x86_64.gppkg
 
 - name: bin_gpdb_centos7
@@ -82,30 +85,27 @@ resources:
 # centtos 6
 
 - name: plr_gpdb_centos6_build
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
+    region_name: us-west-1
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
     versioned_file: build/gpdb6/plr/centos6/plr-devel.gppkg
 
 - name: plr_gpdb_centos6_release
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
+    region_name: us-west-1
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
     regexp: release/gpdb6/plr/plr-(.*)-rhel6-x86_64.gppkg
 
 - name: plr_gpdb_centos6_release_candidate
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
+    region_name: us-west-1
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
     regexp: release_candidate/gpdb6/plr/plr-(.*)-rhel6-x86_64.gppkg
 
 - name: bin_gpdb_centos6

--- a/concourse/pipeline/pipeline-release.yml
+++ b/concourse/pipeline/pipeline-release.yml
@@ -201,3 +201,18 @@ jobs:
       OSVER: centos7
       GPDBVER: gp6
 
+- name: manual_push_centos7_release
+  plan:
+  - aggregate:
+    - get: plr_gpdb_centos7_release_candidate
+  - put: plr_gpdb_centos7_release
+    params:
+	  file: plr_gpdb_centos7_release_candidate/plr-*.gppkg
+
+- name: manual_push_centos6_release
+  plan:
+  - aggregate:
+    - get: plr_gpdb_centos6_release_candidate
+  - put: plr_gpdb_centos6_release
+    params:
+	  file: plr_gpdb_centos6_release_candidate/plr-*.gppkg

--- a/concourse/pipeline/pipeline-release.yml
+++ b/concourse/pipeline/pipeline-release.yml
@@ -9,6 +9,8 @@ groups:
     - plr_centos7_release
     - plr_centos6_test
     - plr_centos7_test
+    - manual_push_centos6_release
+    - manual_push_centos7_release
 
 resource_types:
 - name: gcs
@@ -53,25 +55,22 @@ resources:
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    region_name: us-west-1
-    bucket: {{pl-bucket-name}}
-    versioned_file: build/gpdb6/plr/centos7/plr-devel.gppkg
+    bucket: {{gcs-bucket-dev}}
+    versioned_file: plr/gpdb6/plr-rhel7.gppkg
 
 - name: plr_gpdb_centos7_release
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    region_name: us-west-1
-    secret_access_key: {{bucket-secret-access-key}}
-    regexp: release/gpdb6/plr/plr-(.*)-rhel7-x86_64.gppkg
+    bucket: {{gcs-bucket}}
+    regexp: plr/released/gpdb6/plr-(.*)-rhel7-x86_64.gppkg
 
 - name: plr_gpdb_centos7_release_candidate
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    region_name: us-west-1
-    bucket: {{pl-bucket-name}}
-    regexp: release_candidate/gpdb6/plr/plr-(.*)-rhel7-x86_64.gppkg
+    bucket: {{gcs-bucket}}
+    regexp: plr/published/gpdb6/plr-(.*)-rhel7-x86_64.gppkg
 
 - name: bin_gpdb_centos7
   type: s3
@@ -88,25 +87,22 @@ resources:
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    region_name: us-west-1
-    bucket: {{pl-bucket-name}}
-    versioned_file: build/gpdb6/plr/centos6/plr-devel.gppkg
+    bucket: {{gcs-bucket-dev}}
+    versioned_file: plr/gpdb6/plr-rhel6.gppkg
 
 - name: plr_gpdb_centos6_release
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    region_name: us-west-1
-    bucket: {{pl-bucket-name}}
-    regexp: release/gpdb6/plr/plr-(.*)-rhel6-x86_64.gppkg
+    bucket: {{gcs-bucket}}
+    regexp: plr/released/gpdb6/plr-(.*)-rhel6-x86_64.gppkg
 
 - name: plr_gpdb_centos6_release_candidate
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    region_name: us-west-1
-    bucket: {{pl-bucket-name}}
-    regexp: release_candidate/gpdb6/plr/plr-(.*)-rhel6-x86_64.gppkg
+    bucket: {{gcs-bucket}}
+    regexp: plr/published/gpdb6/plr-(.*)-rhel6-x86_64.gppkg
 
 - name: bin_gpdb_centos6
   type: s3
@@ -204,15 +200,46 @@ jobs:
 - name: manual_push_centos7_release
   plan:
   - aggregate:
+    - get: centos-gpdb-dev-7
     - get: plr_gpdb_centos7_release_candidate
+  - task: Copy_GPPKG
+    image: centos-gpdb-dev-7
+    config:
+      platform: linux
+      inputs:
+       - name: plr_gpdb_centos7_release_candidate
+      outputs:
+       - name: plr_gpdb_centos7_release
+      run:
+          path: "sh"
+          args:
+            - -exc
+            - |
+              cp plr_gpdb_centos7_release_candidate/plr-*.gppkg plr_gpdb_centos7_release/
   - put: plr_gpdb_centos7_release
     params:
-	  file: plr_gpdb_centos7_release_candidate/plr-*.gppkg
+      file: plr_gpdb_centos7_release/plr-*.gppkg
+
 
 - name: manual_push_centos6_release
   plan:
   - aggregate:
+    - get: centos-gpdb-dev-6
     - get: plr_gpdb_centos6_release_candidate
+  - task: Copy_GPPKG
+    image: centos-gpdb-dev-6
+    config:
+      platform: linux
+      inputs:
+       - name: plr_gpdb_centos6_release_candidate
+      outputs:
+       - name: plr_gpdb_centos6_release
+      run:
+          path: "sh"
+          args:
+            - -exc
+            - |
+              cp plr_gpdb_centos6_release_candidate/plr-*.gppkg plr_gpdb_centos6_release/
   - put: plr_gpdb_centos6_release
     params:
-	  file: plr_gpdb_centos6_release_candidate/plr-*.gppkg
+      file: plr_gpdb_centos6_release/plr-*.gppkg

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -61,9 +61,15 @@ resources:
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    bucket: {{pl-bucket-name}}
-    region_name: us-west-1
-    versioned_file: build/gpdb6/plr/centos7/plr-devel.gppkg
+    bucket: {{gcs-bucket-intermediates}}
+    versioned_file: plr/plr-centos7/gpdb6/plr-devel.gppkg
+
+- name: plr_gpdb_centos6_build
+  type: gcs
+  source:
+    json_key: {{gcs-read-write-service-account-key}}
+    bucket: {{gcs-bucket-intermediates}}
+    versioned_file: plr/plr-centos6/gpdb6/plr-devel.gppkg
 
 - name: bin_gpdb_centos6
   type: s3
@@ -74,13 +80,19 @@ resources:
     secret_access_key: {{bucket-secret-access-key}}
     versioned_file: bin_gpdb_centos/bin_gpdb.tar.gz
 
-- name: plr_gpdb_centos6_build
+- name: plr_gpdb_centos7_bin
   type: gcs
   source:
     json_key: {{gcs-read-write-service-account-key}}
-    bucket: {{pl-bucket-name}}
-    region_name: us-west-1
-    versioned_file: build/gpdb6/plr/centos6/plr-devel.gppkg
+    bucket: {{gcs-bucket}}
+    versioned_file: plr/gpdb6/plr-rhel7.gppkg
+
+- name: plr_gpdb_centos6_bin
+  type: gcs
+  source:
+    json_key: {{gcs-read-write-service-account-key}}
+    bucket: {{gcs-bucket}}
+    versioned_file: plr/gpdb6/plr-rhel6.gppkg
 
 ## jobs
 ## ======================================================================
@@ -159,6 +171,8 @@ jobs:
     input_mapping:
       bin_gpdb: bin_gpdb_centos6
       bin_plr: plr_gpdb_centos6_build
+    output_mapping:
+      plr_gppkg: plr_gpdb_centos6_bin
     params:
       OSVER: centos6
       GPDBVER: gp6
@@ -179,6 +193,8 @@ jobs:
     input_mapping:
       bin_gpdb: bin_gpdb_centos7
       bin_plr: plr_gpdb_centos7_build
+    output_mapping:
+      plr_gppkg: plr_gpdb_centos7_bin
     params:
       OSVER: centos7
       GPDBVER: gp6

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -176,6 +176,10 @@ jobs:
     params:
       OSVER: centos6
       GPDBVER: gp6
+  - aggregate:
+    - put: plr_gpdb_centos6_bin
+      params:
+        file: plr_gppkg/plr-rhel6.gppkg 
 
 - name: plr_centos7_test
   plan:
@@ -198,4 +202,8 @@ jobs:
     params:
       OSVER: centos7
       GPDBVER: gp6
+  - aggregate:
+    - put: plr_gpdb_centos7_bin
+      params:
+        file: plr_gppkg/plr-rhel7.gppkg 
 

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -10,6 +10,12 @@ groups:
     - plr_centos6_test
     - plr_centos7_test
 
+resource_types:
+- name: gcs
+  type: docker-image
+  source:
+    repository: frodenas/gcs-resource
+
 resources:
 
 # Image Resources
@@ -52,12 +58,11 @@ resources:
     versioned_file: bin_gpdb_centos7/bin_gpdb.tar.gz
 
 - name: plr_gpdb_centos7_build
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
+    region_name: us-west-1
     versioned_file: build/gpdb6/plr/centos7/plr-devel.gppkg
 
 - name: bin_gpdb_centos6
@@ -70,12 +75,11 @@ resources:
     versioned_file: bin_gpdb_centos/bin_gpdb.tar.gz
 
 - name: plr_gpdb_centos6_build
-  type: s3
+  type: gcs
   source:
+    json_key: {{gcs-read-write-service-account-key}}
     bucket: {{pl-bucket-name}}
-    region_name: {{aws-region}}
-    access_key_id: {{bucket-access-key-id}}
-    secret_access_key: {{bucket-secret-access-key}}
+    region_name: us-west-1
     versioned_file: build/gpdb6/plr/centos6/plr-devel.gppkg
 
 ## jobs

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -38,13 +38,13 @@ function test() {
 
     case "$OSVER" in
     suse11)
-        cp bin_plr/plr-*.gppkg plr_gppkg/plr-2.3.0-$GPDBVER-sles11-x86_64.gppkg
+        cp bin_plr/plr-*.gppkg plr_gppkg/plr-sles11.gppkg
       ;;
     centos6)
-        cp bin_plr/plr-*.gppkg plr_gppkg/plr-2.3.0-$GPDBVER-rhel6-x86_64.gppkg
+        cp bin_plr/plr-*.gppkg plr_gppkg/plr-rhel6.gppkg
       ;;
     centos7)
-        cp bin_plr/plr-*.gppkg plr_gppkg/plr-2.3.0-$GPDBVER-rhel7-x86_64.gppkg
+        cp bin_plr/plr-*.gppkg plr_gppkg/plr-rhel7.gppkg
       ;;
     *) echo "Unknown OS: $OSVER"; exit 1 ;;
   esac


### PR DESCRIPTION
1. Update pipeline yaml for new GCP/GCS
2. Move bucket from S3 to GCS

Co-authored-by: Hubert Zhang <zhanghuan929@gmail.com>
Co-authored-by: Haozhou Wang <hawang@pivotal.io>