### PR TITLE
Backport PLR commit and update release pipeline to gpdb5

### DIFF
--- a/concourse/pipeline/pipeline-release-gpdb5.yml
+++ b/concourse/pipeline/pipeline-release-gpdb5.yml
@@ -39,7 +39,7 @@ resources:
 - name: plr_src
   type: git
   source:
-    branch: master
+    branch: gpdb5
     uri: https://github.com/greenplum-db/plr.git
     tag_filter: 2.*
 

--- a/regress/expected/bad_fun.out
+++ b/regress/expected/bad_fun.out
@@ -1,0 +1,13 @@
+-- should error out but should not crash PG
+CREATE OR REPLACE
+FUNCTION r_bad_fun()
+RETURNS int4 AS
+$BODY$
+  deadbeef <- function(,bad) {}
+  42
+$BODY$
+LANGUAGE plr;
+SELECT r_bad_fun();
+ERROR:  R interpreter parse error
+DETAIL:  Error: bad value
+CONTEXT:  In PL/R function r_bad_fun

--- a/regress/sql/bad_fun.sql
+++ b/regress/sql/bad_fun.sql
@@ -1,0 +1,11 @@
+-- should error out but should not crash PG
+CREATE OR REPLACE
+FUNCTION r_bad_fun()
+RETURNS int4 AS
+$BODY$
+  deadbeef <- function(,bad) {}
+  42
+$BODY$
+LANGUAGE plr;
+
+SELECT r_bad_fun();

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ SHLIB_LINK	+= -L$(r_libdir1x) -L$(r_libdir2x) -lR
 DATA_built	= plr.sql
 DATA		= plr--8.3.0.16.sql plr--unpackaged--8.3.0.16.sql
 DOCS		= README.plr
-REGRESS		= plr
+REGRESS		= plr bad_fun
 EXTRA_CLEAN	= doc/html/* doc/plr-US.aux doc/plr-*.log doc/plr-*.out doc/plr-*.pdf doc/plr-*.tex-pdf
 
 ifdef USE_PGXS
@@ -74,7 +74,6 @@ override CPPFLAGS += -DPKGLIBDIR=\"$(pkglibdir)\" -DDLSUFFIX=\"$(DLSUFFIX)\"
 override CPPFLAGS += -DR_HOME_DEFAULT=\"$(rhomedef)\"
 
 REGRESS_OPTS = --dbname=$(PL_TESTDB)
-REGRESS = plr
 
 .PHONY: release
 release:


### PR DESCRIPTION
1. This is a backport patch from
postgres-plr/plr@c42eb9c
to fix GPDB crash, when the R function is not correct in UDF

2. Change release pipeline plr source from master to gpdb5