### PR TITLE
Add ubuntu support for plr & gpdb 6X

### DIFF
--- a/concourse/pipeline/pipeline-release.yml
+++ b/concourse/pipeline/pipeline-release.yml
@@ -7,8 +7,10 @@ groups:
   jobs:
     - plr_centos6_release
     - plr_centos7_release
+    - plr_ubuntu18_release
     - plr_centos6_test
     - plr_centos7_test
+    - plr_ubuntu18_test
 
 resource_types:
 - name: gcs
@@ -31,6 +33,12 @@ resources:
   source:
     repository: pivotaldata/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
+
+- name: ubuntu18-image
+  type: docker-image
+  source:
+    repository: pivotaldata/ubuntu-gpdb-dev
+    tag: '16.04'
 
 # Github Source Codes
 
@@ -70,7 +78,7 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/bin_gpdb_centos7/bin_gpdb.tar.gz
 
-# centtos 6
+# centos 6
 
 - name: plr_gpdb_centos6_build
   type: gcs
@@ -93,6 +101,31 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/bin_gpdb_centos6/bin_gpdb.tar.gz
 
+# ubuntu 18
+
+- name: plr_gpdb_ubuntu18_build
+  type: gcs
+  source:
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    bucket: {{gcs-bucket-intermediates}}
+    regexp: plr/published/gpdb6/plr-ubuntu18.gppkg
+
+- name: plr_gpdb_ubuntu18_release
+  type: gcs
+  source:
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    bucket: {{gcs-bucket}}
+    regexp: plr/released/gpdb6/plr-(.*)-ubuntu18-amd64.gppkg
+
+- name: bin_gpdb_ubuntu18
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: build/gpdb_6x/bin_gpdb_ubuntu16/bin_gpdb.tar.gz
+
 ## ======================================================================
 ## jobs
 ## ======================================================================
@@ -103,12 +136,11 @@ jobs:
     - get: centos-gpdb-dev-6
     - get: plr_src
       trigger: true
-    - get: plr_gpdb_centos6_build
+    - get: bin_plr
+      resource: plr_gpdb_centos6_build
   - task: release_PLR
     file: plr_src/concourse/tasks/release_plr.yml
     image: centos-gpdb-dev-6
-    input_mapping:
-      bin_plr: plr_gpdb_centos6_build
     output_mapping:
         plr_gppkg: plr_gpdb_centos6_release
     params:
@@ -124,12 +156,11 @@ jobs:
     - get: centos-gpdb-dev-7
     - get: plr_src
       trigger: true
-    - get: plr_gpdb_centos7_build
+    - get: bin_plr
+      resource: plr_gpdb_centos7_build
   - task: release_PLR
     file: plr_src/concourse/tasks/release_plr.yml
     image: centos-gpdb-dev-7
-    input_mapping:
-      bin_plr: plr_gpdb_centos7_build
     output_mapping:
       plr_gppkg: plr_gpdb_centos7_release
     params:
@@ -139,41 +170,80 @@ jobs:
     params:
       file: plr_gpdb_centos7_release/plr-*.gppkg
 
+- name: plr_ubuntu18_release
+  plan:
+  - aggregate:
+    - get: ubuntu18-image
+    - get: plr_src
+      trigger: true
+    - get: bin_plr
+      resource: plr_gpdb_ubuntu18_build
+  - task: release_PLR
+    file: plr_src/concourse/tasks/release_plr.yml
+    image: ubuntu18-image
+    output_mapping:
+      plr_gppkg: plr_gpdb_ubuntu18_release
+    params:
+      OSVER: ubuntu18
+      GPDBVER: gp6
+  - put: plr_gpdb_ubuntu18_release
+    params:
+      file: plr_gpdb_ubuntu18_release/plr-*.gppkg
+
 - name: plr_centos6_test
   plan:
   - aggregate:
     - get: centos-gpdb-dev-6
     - get: plr_src
-    - get: plr_gpdb_centos6_release
-    - get: bin_gpdb_centos6
+    - get: bin_plr
+      resource: plr_gpdb_centos6_release
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
       trigger: true
     - get: gpdb_src
   - task: Test_PLR
     file: plr_src/concourse/tasks/test_plr.yml
     image: centos-gpdb-dev-6
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-      bin_plr: plr_gpdb_centos6_release
     params:
       OSVER: centos6
       GPDBVER: gp6
+      BLDARCH: rhel7_x86_64
 
 - name: plr_centos7_test
   plan:
   - aggregate:
     - get: centos-gpdb-dev-7
     - get: plr_src
-    - get: plr_gpdb_centos7_release
-    - get: bin_gpdb_centos7
+    - get: bin_plr
+      resource: plr_gpdb_centos7_release
+    - get: bin_gpdb
+      resource: bin_gpdb_centos7
       trigger: true
     - get: gpdb_src
   - task: Test_PLR
     file: plr_src/concourse/tasks/test_plr.yml
     image: centos-gpdb-dev-7
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos7
-      bin_plr: plr_gpdb_centos7_release
     params:
       OSVER: centos7
       GPDBVER: gp6
+      BLDARCH: rhel6_x86_64
+
+- name: plr_ubuntu18_test
+  plan:
+  - aggregate:
+    - get: ubuntu18-image
+    - get: plr_src
+    - get: bin_plr
+      resource: plr_gpdb_ubuntu18_release
+    - get: bin_gpdb
+      resource: bin_gpdb_ubuntu18
+      trigger: true
+    - get: gpdb_src
+  - task: Test_PLR
+    file: plr_src/concourse/tasks/test_plr.yml
+    image: ubuntu18-image
+    params:
+      OSVER: ubuntu18
+      GPDBVER: gp6
+      BLDARCH: ubuntu18_amd64
 

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -10,6 +10,7 @@ groups:
     - plr_ubuntu18_build
     - plr_centos6_test
     - plr_centos7_test
+    - plr_ubuntu18_test
 
 resource_types:
 - name: gcs
@@ -33,7 +34,7 @@ resources:
     repository: pivotaldata/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
 
-- name: ubuntu18_img
+- name: ubuntu18-image
   type: docker-image
   source:
     repository: pivotaldata/ubuntu-gpdb-dev
@@ -51,7 +52,7 @@ resources:
   type: git
   source:
     branch: gpdb6
-    uri: https://github.com/greenplum-db/plr.git
+    uri: https://github.com/gfphoenix78/plr.git
 
 # centos 7
 
@@ -230,7 +231,7 @@ jobs:
   - aggregate:
     - put: plr_gpdb_centos6_bin
       params:
-        file: plr_gpdb_centos6_bin/plr-rhel6.gppkg 
+        file: plr_gpdb_centos6_bin/plr-rhel6.gppkg
 
 - name: plr_centos7_test
   plan:
@@ -256,5 +257,31 @@ jobs:
   - aggregate:
     - put: plr_gpdb_centos7_bin
       params:
-        file: plr_gpdb_centos7_bin/plr-rhel7.gppkg 
+        file: plr_gpdb_centos7_bin/plr-rhel7.gppkg
+
+- name: plr_ubuntu18_test
+  plan:
+  - aggregate:
+    - get: ubuntu18-image
+    - get: plr_src
+    - get: plr_gpdb_ubuntu18_build
+      passed: [plr_ubuntu18_build]
+      trigger: true
+    - get: bin_gpdb
+      resource: bin_gpdb_ubuntu18
+    - get: gpdb_src
+  - task: Test_PLR
+    file: plr_src/concourse/tasks/test_plr.yml
+    image: ubuntu18-image
+    input_mapping:
+      bin_plr: plr_gpdb_ubuntu18_build
+    output_mapping:
+      plr_gppkg: plr_gpdb_ubuntu18_bin
+    params:
+      OSVER: ubuntu18
+      GPDBVER: gp6
+  - aggregate:
+    - put: plr_gpdb_ubuntu18_bin
+      params:
+        file: plr/plr-*.gppkg
 

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -52,7 +52,7 @@ resources:
   type: git
   source:
     branch: gpdb6
-    uri: https://github.com/gfphoenix78/plr.git
+    uri: https://github.com/greenplum-db/plr.git
 
 # centos 7
 

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -262,7 +262,7 @@ jobs:
   - aggregate:
     - put: plr_gpdb_centos7_bin
       params:
-        file: plr_gpdb_centos7_bin/plr-rhel7.gppkg
+        file: plr_gppkg/plr-rhel7.gppkg
 
 - name: plr_ubuntu18_test
   plan:
@@ -289,5 +289,5 @@ jobs:
   - aggregate:
     - put: plr_gpdb_ubuntu18_bin
       params:
-        file: plr/plr-*.gppkg
+        file: plr_gppkg/plr-*.gppkg
 

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -148,6 +148,7 @@ jobs:
         bin_plr: plr_gpdb_centos7_build
       params:
         OSVER: centos7
+        BLDARCH: rhel7_x86_64
         GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_centos7_build
@@ -174,6 +175,7 @@ jobs:
         bin_plr: plr_gpdb_centos6_build
       params:
         OSVER: centos6
+        BLDARCH: rhel6_x86_64
         GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_centos6_build
@@ -199,7 +201,7 @@ jobs:
         bin_plr: plr_gpdb_ubuntu18_build
       params:
         OSVER: ubuntu18
-        BLD_ARCH: ubuntu18_amd64
+        BLDARCH: ubuntu18_amd64
         GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_ubuntu18_build
@@ -228,6 +230,7 @@ jobs:
       plr_gppkg: plr_gpdb_centos6_bin
     params:
       OSVER: centos6
+      BLDARCH: rhel6_x86_64
       GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_centos6_bin
@@ -254,6 +257,7 @@ jobs:
       plr_gppkg: plr_gpdb_centos7_bin
     params:
       OSVER: centos7
+      BLDARCH: rhel7_x86_64
       GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_centos7_bin
@@ -280,7 +284,7 @@ jobs:
       plr_gppkg: plr_gpdb_ubuntu18_bin
     params:
       OSVER: ubuntu18
-      BLD_ARCH: ubuntu18_amd64
+      BLDARCH: ubuntu18_amd64
       GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_ubuntu18_bin

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -135,15 +135,14 @@ jobs:
     - get: centos-gpdb-dev-7
     - get: plr_src
       trigger: true
-    - get: bin_gpdb_centos7
+    - get: bin_gpdb
+      resource: bin_gpdb_centos7
     - get: gpdb_src
       trigger: true
   - aggregate:
     - task: Build_PLR
       file: plr_src/concourse/tasks/build_plr.yml
       image: centos-gpdb-dev-7
-      input_mapping:
-        bin_gpdb: bin_gpdb_centos7
       output_mapping:
         bin_plr: plr_gpdb_centos7_build
       params:
@@ -162,15 +161,14 @@ jobs:
     - get: centos-gpdb-dev-6
     - get: plr_src
       trigger: true
-    - get: bin_gpdb_centos6
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
     - get: gpdb_src
       trigger: true
   - aggregate:
     - task: Build_PLR
       file: plr_src/concourse/tasks/build_plr.yml
       image: centos-gpdb-dev-6
-      input_mapping:
-        bin_gpdb: bin_gpdb_centos6
       output_mapping:
         bin_plr: plr_gpdb_centos6_build
       params:
@@ -215,17 +213,16 @@ jobs:
   - aggregate:
     - get: centos-gpdb-dev-6
     - get: plr_src
-    - get: plr_gpdb_centos6_build
+    - get: bin_plr
+      resource: plr_gpdb_centos6_build
       passed: [plr_centos6_build]
       trigger: true
-    - get: bin_gpdb_centos6
+    - get: bin_gpdb
+      resource: bin_gpdb_centos6
     - get: gpdb_src
   - task: Test_PLR
     file: plr_src/concourse/tasks/test_plr.yml
     image: centos-gpdb-dev-6
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos6
-      bin_plr: plr_gpdb_centos6_build
     output_mapping:
       plr_gppkg: plr_gpdb_centos6_bin
     params:
@@ -242,17 +239,16 @@ jobs:
   - aggregate:
     - get: centos-gpdb-dev-7
     - get: plr_src
-    - get: plr_gpdb_centos7_build
+    - get: bin_plr
+      resource: plr_gpdb_centos7_build
       passed: [plr_centos7_build]
       trigger: true
-    - get: bin_gpdb_centos7
+    - get: bin_gpdb
+      resource: bin_gpdb_centos7
     - get: gpdb_src
   - task: Test_PLR
     file: plr_src/concourse/tasks/test_plr.yml
     image: centos-gpdb-dev-7
-    input_mapping:
-      bin_gpdb: bin_gpdb_centos7
-      bin_plr: plr_gpdb_centos7_build
     output_mapping:
       plr_gppkg: plr_gpdb_centos7_bin
     params:
@@ -269,7 +265,8 @@ jobs:
   - aggregate:
     - get: ubuntu18-image
     - get: plr_src
-    - get: plr_gpdb_ubuntu18_build
+    - get: bin_plr
+      resource: plr_gpdb_ubuntu18_build
       passed: [plr_ubuntu18_build]
       trigger: true
     - get: bin_gpdb
@@ -278,8 +275,6 @@ jobs:
   - task: Test_PLR
     file: plr_src/concourse/tasks/test_plr.yml
     image: ubuntu18-image
-    input_mapping:
-      bin_plr: plr_gpdb_ubuntu18_build
     output_mapping:
       plr_gppkg: plr_gpdb_ubuntu18_bin
     params:

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -235,7 +235,7 @@ jobs:
   - aggregate:
     - put: plr_gpdb_centos6_bin
       params:
-        file: plr_gpdb_centos6_bin/plr-rhel6.gppkg
+        file: plr_gpdb_centos6_bin/plr-*.gppkg
 
 - name: plr_centos7_test
   plan:
@@ -262,7 +262,7 @@ jobs:
   - aggregate:
     - put: plr_gpdb_centos7_bin
       params:
-        file: plr_gppkg/plr-rhel7.gppkg
+        file: plr_gpdb_centos7_bin/plr-*.gppkg
 
 - name: plr_ubuntu18_test
   plan:
@@ -289,5 +289,5 @@ jobs:
   - aggregate:
     - put: plr_gpdb_ubuntu18_bin
       params:
-        file: plr_gppkg/plr-*.gppkg
+        file: plr_gpdb_ubuntu18_bin/plr-*.gppkg
 

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -199,6 +199,7 @@ jobs:
         bin_plr: plr_gpdb_ubuntu18_build
       params:
         OSVER: ubuntu18
+        BLD_ARCH: ubuntu18_amd64
         GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_ubuntu18_build
@@ -279,6 +280,7 @@ jobs:
       plr_gppkg: plr_gpdb_ubuntu18_bin
     params:
       OSVER: ubuntu18
+      BLD_ARCH: ubuntu18_amd64
       GPDBVER: gp6
   - aggregate:
     - put: plr_gpdb_ubuntu18_bin

--- a/concourse/pipeline/pipeline.yml
+++ b/concourse/pipeline/pipeline.yml
@@ -7,6 +7,7 @@ groups:
   jobs:
     - plr_centos7_build
     - plr_centos6_build
+    - plr_ubuntu18_build
     - plr_centos6_test
     - plr_centos7_test
 
@@ -32,6 +33,12 @@ resources:
     repository: pivotaldata/centos-gpdb-dev
     tag: '7-gcc6.2-llvm3.7'
 
+- name: ubuntu18_img
+  type: docker-image
+  source:
+    repository: pivotaldata/ubuntu-gpdb-dev
+    tag: '16.04'
+
 # Github Source Codes
 
 - name: gpdb_src
@@ -55,6 +62,22 @@ resources:
     json_key: ((concourse-gcs-resources-service-account-key))
     versioned_file: 6X_STABLE/bin_gpdb_centos7/bin_gpdb.tar.gz
 
+- name: bin_gpdb_centos6
+  type: gcs
+  source:
+    bucket: ((gcs-bucket-intermediates))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    versioned_file: 6X_STABLE/bin_gpdb_centos6/bin_gpdb.tar.gz
+
+- name: bin_gpdb_ubuntu18
+  type: s3
+  source:
+    access_key_id: {{bucket-access-key-id}}
+    bucket: {{bucket-name}}
+    region_name: {{aws-region}}
+    secret_access_key: {{bucket-secret-access-key}}
+    versioned_file: build/gpdb_6x/bin_gpdb_ubuntu16/bin_gpdb.tar.gz
+
 - name: plr_gpdb_centos7_build
   type: gcs
   source:
@@ -69,12 +92,12 @@ resources:
     bucket: {{gcs-bucket-intermediates}}
     versioned_file: plr/plr-centos6/gpdb6/plr-devel.gppkg
 
-- name: bin_gpdb_centos6
+- name: plr_gpdb_ubuntu18_build
   type: gcs
   source:
-    bucket: ((gcs-bucket-intermediates))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    versioned_file: 6X_STABLE/bin_gpdb_centos6/bin_gpdb.tar.gz
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    bucket: {{gcs-bucket-intermediates}}
+    versioned_file: plr/plr-ubuntu18/gpdb6/plr-devel.gppkg
 
 - name: plr_gpdb_centos7_bin
   type: gcs
@@ -89,6 +112,13 @@ resources:
     json_key: {{concourse-gcs-resources-service-account-key}}
     bucket: {{gcs-bucket-intermediates}}
     regexp: plr/published/gpdb6/plr-rhel6.gppkg
+
+- name: plr_gpdb_ubuntu18_bin
+  type: gcs
+  source:
+    json_key: {{concourse-gcs-resources-service-account-key}}
+    bucket: {{gcs-bucket-intermediates}}
+    regexp: plr/published/gpdb6/plr-ubuntu18.gppkg
 
 ## jobs
 ## ======================================================================
@@ -148,6 +178,31 @@ jobs:
     - put: plr_gpdb_centos6_build
       params:
         file: plr_gpdb_centos6_build/plr-*.gppkg
+
+- name: plr_ubuntu18_build
+  max_in_flight: 3
+  plan:
+  - aggregate:
+    - get: ubuntu18-image
+    - get: plr_src
+      trigger: true
+    - get: bin_gpdb
+      resource: bin_gpdb_ubuntu18
+    - get: gpdb_src
+      trigger: true
+  - aggregate:
+    - task: Build_PLR
+      file: plr_src/concourse/tasks/build_plr.yml
+      image: ubuntu18-image
+      output_mapping:
+        bin_plr: plr_gpdb_ubuntu18_build
+      params:
+        OSVER: ubuntu18
+        GPDBVER: gp6
+  - aggregate:
+    - put: plr_gpdb_ubuntu18_build
+      params:
+        file: plr_gpdb_ubuntu18_build/plr-*.gppkg
 
 # Test PL/R GPPKG
 

--- a/concourse/scripts/build_plr.sh
+++ b/concourse/scripts/build_plr.sh
@@ -12,15 +12,16 @@ source "${TOP_DIR}/gpdb_src/concourse/scripts/common.bash"
 function install_R() {
 case $OSVER in
 centos*)
-	yum install -y R pkg-config
-	;;
+    yum install -y R pkg-config
+    ;;
 ubuntu*)
-	apt update
-	apt install -y r-base pkg-config
-	;;
+    apt update
+    apt install -y r-base pkg-config
+    ;;
 *)
-	echo "unknown OSVER = $OSVER"
-	;;
+    echo "unknown OSVER = $OSVER"
+    exit 1
+    ;;
 esac
 }
 

--- a/concourse/scripts/build_plr.sh
+++ b/concourse/scripts/build_plr.sh
@@ -13,15 +13,13 @@ function install_R() {
 case $OSVER in
 centos*)
 	yum install -y R
-	export R_HOME=/usr/lib64/R
 	;;
 ubuntu*)
 	apt update
 	apt install -y r-base
-	export R_HOME=/usr/lib/R
 	;;
 *)
-	echo "unknown OS = $OS"
+	echo "unknown OSVER = $OSVER"
 	;;
 esac
 }
@@ -30,7 +28,6 @@ function pkg() {
     ## Install R before source greenplum_path
     install_R
     which R
-    echo "R_HOME='$R_HOME'"
     
     [ -f /opt/gcc_env.sh ] && source /opt/gcc_env.sh
     source /usr/local/greenplum-db-devel/greenplum_path.sh

--- a/concourse/scripts/build_plr.sh
+++ b/concourse/scripts/build_plr.sh
@@ -32,7 +32,7 @@ function pkg() {
     which R
     echo "R_HOME='$R_HOME'"
     
-    source /opt/gcc_env.sh
+    [ -f /opt/gcc_env.sh ] && source /opt/gcc_env.sh
     source /usr/local/greenplum-db-devel/greenplum_path.sh
 
     export USE_PGXS=1

--- a/concourse/scripts/build_plr.sh
+++ b/concourse/scripts/build_plr.sh
@@ -12,11 +12,11 @@ source "${TOP_DIR}/gpdb_src/concourse/scripts/common.bash"
 function install_R() {
 case $OSVER in
 centos*)
-	yum install -y R
+	yum install -y R pkg-config
 	;;
 ubuntu*)
 	apt update
-	apt install -y r-base
+	apt install -y r-base pkg-config
 	;;
 *)
 	echo "unknown OSVER = $OSVER"

--- a/concourse/scripts/build_plr.sh
+++ b/concourse/scripts/build_plr.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -l
 
+# OSVER : centos6, centos7, ubuntu18
+
 set -exo pipefail
 
 CWDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -7,14 +9,32 @@ TOP_DIR=${CWDIR}/../../../
 
 source "${TOP_DIR}/gpdb_src/concourse/scripts/common.bash"
 
+function install_R() {
+case $OSVER in
+centos*)
+	yum install -y R
+	export R_HOME=/usr/lib64/R
+	;;
+ubuntu*)
+	apt update
+	apt install -y r-base
+	export R_HOME=/usr/lib/R
+	;;
+*)
+	echo "unknown OS = $OS"
+	;;
+esac
+}
+
 function pkg() {
     ## Install R before source greenplum_path
-    yum install -y R
+    install_R
+    which R
+    echo "R_HOME='$R_HOME'"
     
-	source /opt/gcc_env.sh
+    source /opt/gcc_env.sh
     source /usr/local/greenplum-db-devel/greenplum_path.sh
 
-    export R_HOME=/usr/lib64/R
     export USE_PGXS=1
     pushd plr_src/src
     make clean

--- a/concourse/scripts/release_plr.sh
+++ b/concourse/scripts/release_plr.sh
@@ -15,6 +15,9 @@ function release_gpdb() {
     centos7)
         cp bin_plr/plr-*.gppkg plr_gppkg/plr-$PLR_VERSION-$GPDBVER-rhel7-x86_64.gppkg
       ;;
+    ubuntu18)
+        cp bin_plr/plr-*.gppkg plr_gppkg/plr-$PLR_VERSION-$GPDBVER-ubuntu18-amd64.gppkg
+      ;;
     *) echo "Unknown OS: $OSVER"; exit 1 ;;
   esac
 }

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -47,7 +47,7 @@ function test() {
         cp bin_plr/plr-*.gppkg plr_gppkg/plr-rhel7.gppkg
       ;;
     ubuntu18)
-        cp bin_plr/plr-*.gppkg plr_gppkg/plr_ubuntu18.gppkg
+        cp bin_plr/plr-*.gppkg plr_gppkg/plr-ubuntu18.gppkg
       ;;
     *) echo "Unknown OS: $OSVER"; exit 1 ;;
   esac

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -71,7 +71,19 @@ function setup_gpadmin_user() {
 
 function install_R()
 {
-	yum install -y R
+case $OSVER in
+centos*)
+    yum install -y R pkg-config
+    ;;
+ubuntu*)
+    apt update
+    apt install -y r-base pkg-config
+    ;;
+*)
+    echo "unknown OSVER = $OSVER"
+    exit 1
+    ;;
+esac
 }
 
 function _main() {

--- a/concourse/scripts/test_plr.sh
+++ b/concourse/scripts/test_plr.sh
@@ -46,6 +46,9 @@ function test() {
     centos7)
         cp bin_plr/plr-*.gppkg plr_gppkg/plr-rhel7.gppkg
       ;;
+    ubuntu18)
+        cp bin_plr/plr-*.gppkg plr_gppkg/plr_ubuntu18.gppkg
+      ;;
     *) echo "Unknown OS: $OSVER"; exit 1 ;;
   esac
 }
@@ -57,6 +60,9 @@ function setup_gpadmin_user() {
         ;;
         centos*)
         ${GPDB_CONCOURSE_DIR}/setup_gpadmin_user.bash "centos"
+        ;;
+        ubuntu*)
+        ${GPDB_CONCOURSE_DIR}/setup_gpadmin_user.bash "ubuntu"
         ;;
         *) echo "Unknown OS: $OSVER"; exit 1 ;;
     esac

--- a/concourse/tasks/build_plr.yml
+++ b/concourse/tasks/build_plr.yml
@@ -14,4 +14,4 @@ run:
 params:
   OSVER:
   GPDBVER:
-  BLD_ARCH:
+  BLDARCH:

--- a/concourse/tasks/build_plr.yml
+++ b/concourse/tasks/build_plr.yml
@@ -14,3 +14,4 @@ run:
 params:
   OSVER:
   GPDBVER:
+  BLD_ARCH:

--- a/concourse/tasks/release_plr.yml
+++ b/concourse/tasks/release_plr.yml
@@ -13,3 +13,4 @@ run:
 params:
   OSVER:
   GPDBVER:
+  BLDARCH:

--- a/concourse/tasks/test_plr.yml
+++ b/concourse/tasks/test_plr.yml
@@ -15,3 +15,4 @@ run:
 params:
   OSVER:
   GPDBVER:
+  BLDARCH:

--- a/gppkg/Makefile
+++ b/gppkg/Makefile
@@ -1,6 +1,5 @@
-ifneq (,${R_HOME})
-
 SHELL=/bin/bash
+R_HOME=$(R RHOME)
 all: gppkg
 
 PGXS := $(shell pg_config --pgxs)
@@ -39,12 +38,3 @@ cleanall: clean
 	rm -rf $(PLR_RPM)
 	rm -rf $(PLR_GPPKG)
 
-else
-
-all:
-	@echo ""; \
-	 echo "*** Cannot build PL/R because R_HOME cannot be found." ; \
-	 echo "*** Refer to the documentation for details."; \
-	 echo ""
-
-endif

--- a/gppkg/Makefile
+++ b/gppkg/Makefile
@@ -1,6 +1,8 @@
 SHELL=/bin/bash
-R_HOME=$(R RHOME)
+R_HOME=$(shell R RHOME)
 export R_HOME
+R_VER=$(shell R --version | sed -nr 's/.*version\s+([0-9.]+)\s+.*/\1/p')
+export R_VER
 
 # default target
 all: gppkg
@@ -26,12 +28,12 @@ ifeq ($(OS0), ubuntu)
 include gppkg_deb.mk
 endif
 
-.PHONY: gppkg
+.PHONY: gppkg gppkg_spec.yml distro
 gppkg: clean gppkg_spec.yml distro
 
 gppkg_spec.yml: gppkg_spec.yml.in
 	cat $< | sed "s/#arch/$(ARCH)/g" | sed "s/#os/$(OS)/g" | sed 's/#gpver/$(GP_VERSION_NUM)/g' | sed "s/#gppkgver/$(PLR_VER).$(PLR_REL)/g" > $@
 
-.PHONY: cleanall
+.PHONY: cleanall clean
 cleanall: clean
 

--- a/gppkg/Makefile
+++ b/gppkg/Makefile
@@ -20,11 +20,11 @@ include $(PLR_DIR)/gppkg/release.mk
 #
 # Generic rules to build gppkgs included here
 #
-OS0=$(shell echo $(OS) | sed -n "s/[0-9]\+//p")
-ifeq ($(OS0), rhel)
+OSNAME=$(shell echo $(OS) | sed -n "s/[0-9]\+//p")
+ifeq ($(OSNAME), rhel)
 include gppkg_rpm.mk
 endif
-ifeq ($(OS0), ubuntu)
+ifeq ($(OSNAME), ubuntu)
 include gppkg_deb.mk
 endif
 

--- a/gppkg/Makefile
+++ b/gppkg/Makefile
@@ -10,7 +10,7 @@ all: gppkg
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 
-OS=$(word 1,$(subst _, ,$(BLD_ARCH)))
+OS=$(word 1,$(subst _, ,$(BLDARCH)))
 ARCH=$(shell uname -p)
 
 PLR_DIR=$(shell cd .. && pwd)

--- a/gppkg/Makefile
+++ b/gppkg/Makefile
@@ -1,5 +1,8 @@
 SHELL=/bin/bash
 R_HOME=$(R RHOME)
+export R_HOME
+
+# default target
 all: gppkg
 
 PGXS := $(shell pg_config --pgxs)
@@ -9,32 +12,26 @@ OS=$(word 1,$(subst _, ,$(BLD_ARCH)))
 ARCH=$(shell uname -p)
 
 PLR_DIR=$(shell cd .. && pwd)
+export PLR_DIR
 include $(PLR_DIR)/gppkg/release.mk
-
-PLR_GPPKG_VER=ossv$(PLR_OSS_VER)_pv$(PLR_VER).$(PLR_REL)-GPDB-$(GP_VERSION)-orca
-GPPKG_VERSION=$(PLR_GPPKG_VER)
-PLR_RPM_FLAGS="--define 'plr_dir $(PLR_DIR)/src' --define 'plr_ver $(PLR_VER)' --define 'plr_rel $(PLR_REL)' --define 'r_ver $(R_VER)' --define 'r_dir $(R_HOME)'"
-PLR_RPM=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).rpm
-PLR_GPPKG=plr-$(PLR_GPPKG_VER)-$(OS)-$(ARCH).gppkg
-
-TARGET_GPPKG=$(PLR_GPPKG)
-EXTRA_CLEAN+=$(R_RPM) $(PLR_RPM) $(PLR_GPPKG)
 
 #
 # Generic rules to build gppkgs included here
 #
-include gppkg.mk
+OS0=$(shell echo $(OS) | sed -n "s/[0-9]\+//p")
+ifeq ($(OS0), rhel)
+include gppkg_rpm.mk
+endif
+ifeq ($(OS0), ubuntu)
+include gppkg_deb.mk
+endif
 
 .PHONY: gppkg
-gppkg: 
-	PATH=$(INSTLOC)/bin:$(PATH) $(MAKE) $(PLR_RPM) RPM_FLAGS=$(PLR_RPM_FLAGS)
-	$(MAKE) $(PLR_GPPKG) MAIN_RPM=$(PLR_RPM)
+gppkg: clean gppkg_spec.yml distro
+
+gppkg_spec.yml: gppkg_spec.yml.in
+	cat $< | sed "s/#arch/$(ARCH)/g" | sed "s/#os/$(OS)/g" | sed 's/#gpver/$(GP_VERSION_NUM)/g' | sed "s/#gppkgver/$(PLR_VER).$(PLR_REL)/g" > $@
 
 .PHONY: cleanall
 cleanall: clean
-	rm -rf BUILDROOT
-	rm -rf SOURCES
-	rm -rf SRPMS
-	rm -rf $(PLR_RPM)
-	rm -rf $(PLR_GPPKG)
 

--- a/gppkg/gppkg_deb.mk
+++ b/gppkg/gppkg_deb.mk
@@ -23,7 +23,7 @@ distro: $(TARGET_GPPKG)
 	rm -rf UBUNTU 2>/dev/null
 	mkdir UBUNTU/DEBIAN -p
 	cat $(PWD)/$(CONTROL_NAME) | sed -r "s|#version|$(PLR_VER).$(PLR_REL)|" | sed -r "s|#arch|$(ARCH)|" > $(PWD)/UBUNTU/DEBIAN/control
-	$(MAKE) -C $(PLR_DIR) install DESTDIR=$(PWD)/UBUNTU libdir=/lib/postgresql pkglibdir=/lib/postgresql datadir=/share/postgresql
+	$(MAKE) -C $(PLR_DIR)/src install DESTDIR=$(PWD)/UBUNTU libdir=/lib/postgresql pkglibdir=/lib/postgresql datadir=/share/postgresql
 	dpkg-deb --build $(PWD)/UBUNTU "$(PLR_DEB)"
 
 %.gppkg: $(PLR_DEB) $(DEPENDENT_DEBS)

--- a/gppkg/gppkg_deb.mk
+++ b/gppkg/gppkg_deb.mk
@@ -3,7 +3,7 @@ include $(PGXS)
 
 GP_VERSION_NUM := $(GP_MAJORVERSION)
 
-OS=$(word 1,$(subst _, ,$(BLD_ARCH)))
+OS=$(word 1,$(subst _, ,$(BLDARCH)))
 ARCH=$(shell uname -p)
 
 ifeq ($(ARCH),x86_64)

--- a/gppkg/gppkg_deb.mk
+++ b/gppkg/gppkg_deb.mk
@@ -1,0 +1,43 @@
+PGXS := $(shell pg_config --pgxs)
+include $(PGXS)
+
+GP_VERSION_NUM := $(GP_MAJORVERSION)
+
+OS=$(word 1,$(subst _, ,$(BLD_ARCH)))
+ARCH=$(shell uname -p)
+
+ifeq ($(ARCH),x86_64)
+ARCH=amd64
+endif
+
+include release.mk
+PLR_DEB=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).deb
+
+PWD=$(shell pwd)
+
+.PHONY: distro
+distro: $(TARGET_GPPKG)
+
+%.deb:
+	rm -rf UBUNTU 2>/dev/null
+	mkdir UBUNTU/DEBIAN -p
+	cat $(PWD)/$(CONTROL_NAME) | sed -r "s|#version|$(PLR_VER)-$(PLR_REL)|" | sed -r "s|#arch|$(ARCH)|" > $(PWD)/UBUNTU/DEBIAN/control
+	$(MAKE) -C $(PLR_DIR) install DESTDIR=$(PWD)/UBUNTU libdir=/lib/postgresql pkglibdir=/lib/postgresql datadir=/share/postgresql
+	dpkg-deb --build $(PWD)/UBUNTU "$(PLR_DEB)"
+
+%.gppkg: $(PLR_DEB) $(DEPENDENT_DEBS)
+	rm -rf gppkg
+	mkdir -p gppkg/deps
+	cp gppkg_spec.yml gppkg/
+	cp $(PLR_DEB) gppkg/
+ifdef DEPENDENT_DEBS
+	for dep_deb in $(DEPENDENT_DEBS); do \
+		cp $${dep_deb} gppkg/deps; \
+	done
+endif
+	gppkg --build gppkg
+
+clean:
+	rm -rf UBUNTU
+	rm -rf gppkg
+	rm -f gppkg_spec.yml

--- a/gppkg/gppkg_deb.mk
+++ b/gppkg/gppkg_deb.mk
@@ -13,7 +13,7 @@ endif
 include release.mk
 CONTROL_NAME=plr_deb.control
 PLR_DEB=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).deb
-TARGET_GPPKG=plr-$(PLR_VER).$(PLR_REL)-$(ARCH).gppkg
+TARGET_GPPKG=plr-$(PLR_VER).$(PLR_REL)-$(GPDBVER)-$(ARCH).gppkg
 PWD=$(shell pwd)
 
 .PHONY: distro

--- a/gppkg/gppkg_deb.mk
+++ b/gppkg/gppkg_deb.mk
@@ -11,8 +11,9 @@ ARCH=amd64
 endif
 
 include release.mk
+CONTROL_NAME=plr_deb.control
 PLR_DEB=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).deb
-
+TARGET_GPPKG=plr-$(PLR_VER).$(PLR_REL)-$(ARCH).gppkg
 PWD=$(shell pwd)
 
 .PHONY: distro
@@ -21,7 +22,7 @@ distro: $(TARGET_GPPKG)
 %.deb:
 	rm -rf UBUNTU 2>/dev/null
 	mkdir UBUNTU/DEBIAN -p
-	cat $(PWD)/$(CONTROL_NAME) | sed -r "s|#version|$(PLR_VER)-$(PLR_REL)|" | sed -r "s|#arch|$(ARCH)|" > $(PWD)/UBUNTU/DEBIAN/control
+	cat $(PWD)/$(CONTROL_NAME) | sed -r "s|#version|$(PLR_VER).$(PLR_REL)|" | sed -r "s|#arch|$(ARCH)|" > $(PWD)/UBUNTU/DEBIAN/control
 	$(MAKE) -C $(PLR_DIR) install DESTDIR=$(PWD)/UBUNTU libdir=/lib/postgresql pkglibdir=/lib/postgresql datadir=/share/postgresql
 	dpkg-deb --build $(PWD)/UBUNTU "$(PLR_DEB)"
 
@@ -40,4 +41,3 @@ endif
 clean:
 	rm -rf UBUNTU
 	rm -rf gppkg
-	rm -f gppkg_spec.yml

--- a/gppkg/gppkg_rpm.mk
+++ b/gppkg/gppkg_rpm.mk
@@ -3,7 +3,7 @@ include $(PGXS)
 
 GP_VERSION_NUM := $(GP_MAJORVERSION)
 
-OS=$(word 1,$(subst _, ,$(BLD_ARCH)))
+OS=$(word 1,$(subst _, ,$(BLDARCH)))
 ARCH=$(shell uname -p)
 
 RPM_ARGS=$(subst -, ,$*)

--- a/gppkg/gppkg_rpm.mk
+++ b/gppkg/gppkg_rpm.mk
@@ -10,7 +10,7 @@ RPM_ARGS=$(subst -, ,$*)
 RPM_NAME=$(word 1,$(RPM_ARGS))
 PLR_RPM=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).rpm
 PLR_RPM_FLAGS= --define 'plr_dir $(PLR_DIR)/src' --define 'plr_ver $(PLR_VER)' --define 'plr_rel $(PLR_REL)' --define 'r_ver $(R_VER)' --define 'r_dir $(R_HOME)'
-TARGET_GPPKG=plr-$(PLR_VER).$(PLR_REL)-$(ARCH).gppkg
+TARGET_GPPKG=plr-$(PLR_VER).$(PLR_REL)-$(GPDBVER)-$(ARCH).gppkg
 PWD=$(shell pwd)
 
 .PHONY: distro

--- a/gppkg/gppkg_rpm.mk
+++ b/gppkg/gppkg_rpm.mk
@@ -9,35 +9,36 @@ ARCH=$(shell uname -p)
 RPM_ARGS=$(subst -, ,$*)
 RPM_NAME=$(word 1,$(RPM_ARGS))
 PLR_RPM=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).rpm
-PLR_RPM_FLAGS="--define 'plr_dir $(PLR_DIR)/src' --define 'plr_ver $(PLR_VER)' --define 'plr_rel $(PLR_REL)' --define 'r_ver $(R_VER)' --define 'r_dir $(R_HOME)'"
+PLR_RPM_FLAGS= --define 'plr_dir $(PLR_DIR)/src' --define 'plr_ver $(PLR_VER)' --define 'plr_rel $(PLR_REL)' --define 'r_ver $(R_VER)' --define 'r_dir $(R_HOME)'
+TARGET_GPPKG=plr-$(PLR_VER).$(PLR_REL)-$(ARCH).gppkg
 PWD=$(shell pwd)
 
 .PHONY: distro
 distro: $(TARGET_GPPKG)
 
-%.rpm: 
+%.rpm:
+	echo "PLR=$(PLR_DIR)"
 	rm -rf RPMS BUILD SPECS
 	mkdir RPMS BUILD SPECS
 	cp $(RPM_NAME).spec SPECS/
-	rpmbuild -bb SPECS/$(RPM_NAME).spec --buildroot $(PWD)/BUILD --define '_topdir $(PWD)' --define '__os_install_post \%{nil}' --define 'buildarch $(ARCH)' $(RPM_FLAGS)
+	rpmbuild -bb SPECS/$(RPM_NAME).spec --buildroot $(PWD)/BUILD --define '_topdir $(PWD)' --define '__os_install_post \%{nil}' --define 'buildarch $(ARCH)' $(PLR_RPM_FLAGS)
 	mv RPMS/$(ARCH)/$*.rpm .
-	rm -rf RPMS BUILD SPECS
+	#rm -rf RPMS BUILD SPECS
 
-%.gppkg: $(MAIN_RPM) $(DEPENDENT_RPMS)
-	mkdir -p gppkg/deps 
+%.gppkg: $(PLR_RPM) $(DEPENDENT_RPMS)
+	mkdir -p gppkg/deps
 	cp gppkg_spec.yml gppkg/
-	cp $(MAIN_RPM) gppkg/ 
+	cp $(PLR_RPM) gppkg/
 ifdef DEPENDENT_RPMS
 	for dep_rpm in $(DEPENDENT_RPMS); do \
 		cp $${dep_rpm} gppkg/deps; \
 	done
 endif
-	source $(GPHOME)/greenplum_path.sh && gppkg --build gppkg 
+	source $(GPHOME)/greenplum_path.sh && gppkg --build gppkg
 
 clean:
-	rm -rf RPMS BUILD SPECS
+	rm -rf RPMS BUILD SPECS SOURCES SRPMS
 	rm -rf gppkg
-	rm -f gppkg_spec.yml
 ifdef EXTRA_CLEAN
 	rm -f $(EXTRA_CLEAN)
 endif

--- a/gppkg/gppkg_rpm.mk
+++ b/gppkg/gppkg_rpm.mk
@@ -8,7 +8,13 @@ ARCH=$(shell uname -p)
 
 RPM_ARGS=$(subst -, ,$*)
 RPM_NAME=$(word 1,$(RPM_ARGS))
+PLR_RPM=plr-$(PLR_VER)-$(PLR_REL).$(ARCH).rpm
+PLR_RPM_FLAGS="--define 'plr_dir $(PLR_DIR)/src' --define 'plr_ver $(PLR_VER)' --define 'plr_rel $(PLR_REL)' --define 'r_ver $(R_VER)' --define 'r_dir $(R_HOME)'"
 PWD=$(shell pwd)
+
+.PHONY: distro
+distro: $(TARGET_GPPKG)
+
 %.rpm: 
 	rm -rf RPMS BUILD SPECS
 	mkdir RPMS BUILD SPECS
@@ -17,10 +23,7 @@ PWD=$(shell pwd)
 	mv RPMS/$(ARCH)/$*.rpm .
 	rm -rf RPMS BUILD SPECS
 
-gppkg_spec.yml: gppkg_spec.yml.in
-	cat $< | sed "s/#arch/$(ARCH)/g" | sed "s/#os/$(OS)/g" | sed 's/#gpver/$(GP_VERSION_NUM)/g' | sed "s/#gppkgver/$(GPPKG_VERSION)/g"> $@ > $@
-
-%.gppkg: gppkg_spec.yml $(MAIN_RPM) $(DEPENDENT_RPMS)
+%.gppkg: $(MAIN_RPM) $(DEPENDENT_RPMS)
 	mkdir -p gppkg/deps 
 	cp gppkg_spec.yml gppkg/
 	cp $(MAIN_RPM) gppkg/ 
@@ -30,7 +33,6 @@ ifdef DEPENDENT_RPMS
 	done
 endif
 	source $(GPHOME)/greenplum_path.sh && gppkg --build gppkg 
-	rm -rf gppkg
 
 clean:
 	rm -rf RPMS BUILD SPECS

--- a/gppkg/plr_deb.control
+++ b/gppkg/plr_deb.control
@@ -1,0 +1,7 @@
+Package: plr
+Version: #version
+Section: base
+Priority: optional
+Architecture: #arch
+Description: PL/R
+  The PL/R modules provides Procedural language implementation of R for Greenplum Database.

--- a/gppkg/release.mk
+++ b/gppkg/release.mk
@@ -2,6 +2,6 @@
 PLR_OSS_VER=8.3.1.15
 
 # Pivotal package version
-PLR_VER=2.3
+PLR_VER=3.0
 PLR_REL=1
 


### PR DESCRIPTION
Update pipelines to support ubuntu. Our goal is to support ubuntu 18.04, but now we use gpdb for ubuntu 16.04 and docker image for ubuntu 16.04. When the gpdb binary for ubuntu 18.04 and docker image for ubuntu 18.04 are ready, we need to swith the two resources and check the pipelines.