### PR TITLE
Rewrite the PostInstall messages

### DIFF
--- a/gppkg/gppkg_spec.yml.in
+++ b/gppkg/gppkg_spec.yml.in
@@ -7,9 +7,11 @@ Description: Provides a procedural language implementation of R for the Greenplu
 PostInstall:
 - Master: "echo '-';
           echo '==========================================================================';
-          echo 'PL/R installation is complete! To proceed, follow these steps:';
-          echo '1. Source your new $GPHOME/greenplum_path.sh file and restart the database.';
-          echo '2. Create PL/R language in the target database with \"create extension plr;\"';
-          echo '3. Optionally you can enable PL/R helper functions in this database by running ';
+          echo 'PL/R installation is complete! To proceed, create PL/R language in the ';
+          echo 'target database with: ';
+          echo '    \"CREATE EXTENSION plr;\"';
+          echo '--------------------------------------------------------------------------';
+          echo '           DEPRECATED                                          ';
+          echo 'In an old way, you can enable PL/R helper functions by running ';
           echo '    \"psql -f $GPHOME/share/postgresql/extension/plr.sql -d mydatabase\"';
           echo '==========================================================================';"


### PR DESCRIPTION
1. re-source $GPHOME/greenplum_path.sh is unneeded, since greenplum_path.sh is not changed
2. Restart database is unneeded
3. The steps 1,2,3 is like a command sequence. But it isn't. The only command to run is `CREATE EXTENSION plr;`
4. The deprecated command is not noticed obviously.