### PR TITLE
Added a dependencies file to let license_finder detect R 

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -1,0 +1,16 @@
+---
+- - :add_package
+  - R
+  - 3.3.3
+  - &1
+    :who: 
+    :why: 
+    :versions: []
+    :when: 2019-06-06 09:09:46.937246000 Z
+- - :license
+  - R
+  - GPL2.0
+  - *1
+- - :approve
+  - R
+  - *1


### PR DESCRIPTION
R will be shipped with PL/R for some platform, such as Ubuntu. We need to add a dependency_desisions file to make license_finder know the dependency.

The command to add a manual dependency

```
license_finder dependencies add R GPL2.0 3.3.3 --approve
```