### PR TITLE
add R project homepage for license_finder

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -6,10 +6,14 @@
     :who: 
     :why: 
     :versions: []
-    :when: 2019-06-06 09:09:46.937246000 Z
+    :when: 2019-06-20 09:09:50.922610000 Z
 - - :license
   - R
   - GPL2.0
+  - *1
+- - :homepage
+  - R
+  - https://svn.r-project.org/R
   - *1
 - - :approve
   - R


### PR DESCRIPTION
Since we add R as a manual dependency for license_finder, we need to add the homepage attribute.