### PR TITLE
Fix PLR_OSS_VER

### DIFF
--- a/gppkg/release.mk
+++ b/gppkg/release.mk
@@ -1,5 +1,5 @@
 # Open source PLR version
-PLR_OSS_VER=8.3.1.15
+PLR_OSS_VER=8.3.0.16
 
 # Pivotal package version
 PLR_VER=3.0
@@ -8,4 +8,3 @@ PLR_REL=1
 # Embedded R version
 R_VER=3.3.3
 R_REL=1
-


### PR DESCRIPTION
In the opensource repo, version 8.3.1.15 does not exist.
ref: https://github.com/postgres-plr/plr/tags