### PR TITLE
Patch R 3.3.3 to solve link error

### DIFF
--- a/concourse/build.sh
+++ b/concourse/build.sh
@@ -8,6 +8,16 @@ TOP_DIR=/home/gpadmin
 # official repo, CentOS6 is not supported for now.
 function build_r() {
     pushd "$(find r_src -maxdepth 1 -type d -regex ".*R.*")"
+
+    if [ "$OS_NAME" = "rhel9" ]; then
+        # Fix gcc10 fortran failure with cmplx.f
+        # See https://stackoverflow.com/questions/63892055/fortran-error-type-mismatch-between-two-unrelated-subroutine-calls
+        export FFLAGS="-fallow-argument-mismatch"
+        # There are many "multiple definition" error with gcc10 and R 3.3.3.
+        # Just turn the error off for el9.
+        export CFLAGS="-fcommon"
+    fi
+
     ./configure --prefix=$R_PREFIX --with-x=no --with-readline=no --enable-R-shlib --disable-rpath
     make -j4
     make install


### PR DESCRIPTION
Missing `extern` keyword in header file fails gcc 10 while linking:

```
/usr/bin/ld: Rdynload.o:/tmp/build/d6b29ed3/r_src/R-3.3.3/src/main/../../src/include/Defn.h:1284: multiple definition of `R_OutputCon'; CommandLineArgs.o:/tmp/build/d6b29ed3/r_src/R-3.3.3/src/main/../../src/include/Defn.h:1284: first defined here
```

Apply the patch before build to fix it.

----

**UPDATE: Too many errors, just suppress those**

- Missing 'extern' keyword in header file fails gcc 10 while linking:

```
/usr/bin/ld: Rdynload.o:/tmp/build/d6b29ed3/r_src/R-3.3.3/src/main/../../src/include/Defn.h:1284: multiple definition of `R_OutputCon'; CommandLineArgs.o:/tmp/build/d6b29ed3/r_src/R-3.3.3/src/main/../../src/include/Defn.h:1284: first defined here
```
  Use "-fcommon" to suppress it.

- Fortran compiling error with gcc10:

```
cmplx.f:55915:56:
33404 |      $                        K, M-K, ONE, C( K+1, 1 ), LDC,
      |                                      2
......
55915 |                   CALL ZGEMM( 'N', 'N', N, IV, N-KI+IV, ONE,
      |                                                        1
Error: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(8)/COMPLEX(8)).
```

  Work around with "-fallow-argument-mismatch".
